### PR TITLE
MNT: Check for module instance

### DIFF
--- a/dedent.js
+++ b/dedent.js
@@ -42,4 +42,6 @@ function dedent(strings, ...values) {
   return lines.map(l => l[0] === " " ? l.slice(mindent) : l).join("\n");
 }
 
-module.exports = dedent;
+if ('undefined' !== typeof module) {
+  module.exports = dedent;
+}

--- a/dist/dedent.js
+++ b/dist/dedent.js
@@ -48,4 +48,6 @@ function dedent(strings) {
   }).join("\n");
 }
 
-module.exports = dedent;
+if ('undefined' !== typeof module) {
+  module.exports = dedent;
+}

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "eslint": "^0.18.0",
     "gulp": "^3.8.10",
     "gulp-babel": "^5.1.0",
-    "jest-cli": "^0.2.1"
+    "jest-cli": "^0.7.1"
   },
   "scripts": {
     "test": "jest",


### PR DESCRIPTION
In browser, via `node_modules` dedent runs into
```js
Uncaught ReferenceError: module is not defined
```
Because it assumes the `window.module` is defined?
```js
module.exports = dedent;
```
Would it be a good idea to check if module exists. Like:
```js
if ('undefined' !== typeof module) {
  module.exports = dedent;
}
```
If not, please feel free to reject this request. :-)