### PR TITLE
Support dedent with default indent

### DIFF
--- a/__tests__/__snapshots__/makeDedent-tests.js.snap
+++ b/__tests__/__snapshots__/makeDedent-tests.js.snap
@@ -1,0 +1,5 @@
+exports[`makeDedent can create a dedent function with default indent 1`] = `
+"    first line
+    second
+    third"
+`;

--- a/__tests__/makeDedent-tests.js
+++ b/__tests__/makeDedent-tests.js
@@ -1,0 +1,19 @@
+// @flow
+
+import { makeDedent } from "../dedent";
+
+describe("makeDedent", () => {
+  it('can create a dedent function', () => {
+    const dd = makeDedent();
+    expect(dd).toBeInstanceOf(Function);
+  });
+
+  it("can create a dedent function with default indent", () => {
+    const dd = makeDedent("    ");
+    expect(dd`
+      first ${"line"}
+      ${"second"}
+      third
+    `).toMatchSnapshot();
+  });
+});

--- a/dedent.js
+++ b/dedent.js
@@ -1,50 +1,62 @@
 // @flow
 
-export default function dedent(
-  strings: string | Array<string>,
-  ...values: Array<string>
-) {
-  // $FlowFixMe: Flow doesn't undestand .raw
-  const raw = typeof strings === "string" ? [strings] : strings.raw;
+export function makeDedent(indent: string = "") {
+  return function dedent(
+    strings: string | Array<string>,
+    ...values: Array<string>
+  ) {
+    // $FlowFixMe: Flow doesn't undestand .raw
+    const raw = typeof strings === "string" ? [strings] : strings.raw;
 
-  // first, perform interpolation
-  let result = "";
-  for (let i = 0; i < raw.length; i++) {
-    result += raw[i]
-      // join lines when there is a suppressed newline
-      .replace(/\\\n[ \t]*/g, "")
-      // handle escaped backticks
-      .replace(/\\`/g, "`");
+    // first, perform interpolation
+    let result = "";
+    for (let i = 0; i < raw.length; i++) {
+      result += raw[i]
+        // join lines when there is a suppressed newline
+        .replace(/\\\n[ \t]*/g, "")
+        // handle escaped backticks
+        .replace(/\\`/g, "`");
 
-    if (i < values.length) {
-      result += values[i];
-    }
-  }
-
-  // now strip indentation
-  const lines = result.split("\n");
-  let mindent: number | null = null;
-  lines.forEach(l => {
-    let m = l.match(/^(\s+)\S+/);
-    if (m) {
-      let indent = m[1].length;
-      if (!mindent) {
-        // this is the first indented line
-        mindent = indent;
-      } else {
-        mindent = Math.min(mindent, indent);
+      if (i < values.length) {
+        result += values[i];
       }
     }
-  });
 
-  if (mindent !== null) {
-    const m = mindent; // appease Flow
-    result = lines.map(l => l[0] === " " ? l.slice(m) : l).join("\n");
-  }
+    // now strip indentation
+    const lines = result.split("\n");
+    let mindent: number | null = null;
+    lines.forEach(l => {
+      let m = l.match(/^(\s+)\S+/);
+      if (m) {
+        let lineIndent = m[1].length;
+        if (!mindent) {
+          // this is the first indented line
+          mindent = lineIndent;
+        } else {
+          mindent = Math.min(mindent, lineIndent);
+        }
+      }
+    });
 
-  return result
-    // dedent eats leading and trailing whitespace too
-    .trim()
-    // handle escaped newlines at the end to ensure they don't get stripped too
-    .replace(/\\n/g, "\n");
+    if (mindent !== null) {
+      const m = mindent; // appease Flow
+      result = lines
+        .map(l => indent + (l[0] === " " ? l.slice(m) : l))
+        .join("\n");
+    }
+
+    return (
+      indent +
+      result
+        // dedent eats leading and trailing whitespace too
+        .trim()
+        // handle escaped newlines at the end to ensure they don't get stripped too
+        .replace(/\\n/g, "\n")
+    );
+  };
 }
+
+// Create the default dedent string tag with no default indent.
+const dedent = makeDedent();
+
+export default dedent;

--- a/dist/dedent.js
+++ b/dist/dedent.js
@@ -3,54 +3,62 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.default = dedent;
-function dedent(strings) {
-  // $FlowFixMe: Flow doesn't undestand .raw
-  var raw = typeof strings === "string" ? [strings] : strings.raw;
+exports.makeDedent = makeDedent;
+function makeDedent() {
+  var indent = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : "";
 
-  // first, perform interpolation
-  var result = "";
-  for (var i = 0; i < raw.length; i++) {
-    result += raw[i].
-    // join lines when there is a suppressed newline
-    replace(/\\\n[ \t]*/g, "").
+  return function dedent(strings) {
+    // $FlowFixMe: Flow doesn't undestand .raw
+    var raw = typeof strings === "string" ? [strings] : strings.raw;
 
-    // handle escaped backticks
-    replace(/\\`/g, "`");
+    // first, perform interpolation
+    var result = "";
+    for (var i = 0; i < raw.length; i++) {
+      result += raw[i]
+      // join lines when there is a suppressed newline
+      .replace(/\\\n[ \t]*/g, "")
+      // handle escaped backticks
+      .replace(/\\`/g, "`");
 
-    if (i < (arguments.length <= 1 ? 0 : arguments.length - 1)) {
-      result += arguments.length <= i + 1 ? undefined : arguments[i + 1];
-    }
-  }
-
-  // now strip indentation
-  var lines = result.split("\n");
-  var mindent = null;
-  lines.forEach(function (l) {
-    var m = l.match(/^(\s+)\S+/);
-    if (m) {
-      var indent = m[1].length;
-      if (!mindent) {
-        // this is the first indented line
-        mindent = indent;
-      } else {
-        mindent = Math.min(mindent, indent);
+      if (i < (arguments.length <= 1 ? 0 : arguments.length - 1)) {
+        result += arguments.length <= i + 1 ? undefined : arguments[i + 1];
       }
     }
-  });
 
-  if (mindent !== null) {
-    (function () {
-      var m = mindent; // appease Flow
-      result = lines.map(function (l) {
-        return l[0] === " " ? l.slice(m) : l;
-      }).join("\n");
-    })();
-  }
+    // now strip indentation
+    var lines = result.split("\n");
+    var mindent = null;
+    lines.forEach(function (l) {
+      var m = l.match(/^(\s+)\S+/);
+      if (m) {
+        var lineIndent = m[1].length;
+        if (!mindent) {
+          // this is the first indented line
+          mindent = lineIndent;
+        } else {
+          mindent = Math.min(mindent, lineIndent);
+        }
+      }
+    });
 
-  return result.
-  // dedent eats leading and trailing whitespace too
-  trim().
-  // handle escaped newlines at the end to ensure they don't get stripped too
-  replace(/\\n/g, "\n");
+    if (mindent !== null) {
+      (function () {
+        var m = mindent; // appease Flow
+        result = lines.map(function (l) {
+          return indent + (l[0] === " " ? l.slice(m) : l);
+        }).join("\n");
+      })();
+    }
+
+    return indent + result
+    // dedent eats leading and trailing whitespace too
+    .trim()
+    // handle escaped newlines at the end to ensure they don't get stripped too
+    .replace(/\\n/g, "\n");
+  };
 }
+
+// Create the default dedent string tag with no default indent.
+var dedent = makeDedent();
+
+exports.default = dedent;


### PR DESCRIPTION
This adds a higher-order function `makeDedent` to allow creation of string tags with default indent. This is useful if all our lines are equally indented but we want to be able to specify an indent for all lines. Right now, using `dedent` strips the indentation from all lines. There is no change in the behavior of the default string tag. I haven't yet updated the readme, will do if this PR can be accepted.

P.S: The irony of supporting indentation in a repo called `dedent` is not lost on me.