### PR TITLE
Publish macros and handle macro case when evaluate fails

### DIFF
--- a/__tests__/__snapshots__/dedent-macro-test.js.snap
+++ b/__tests__/__snapshots__/dedent-macro-test.js.snap
@@ -64,6 +64,22 @@ dedent\`
 "
 `;
 
+exports[`explicit newlines 1`] = `
+"
+import dedent from \"../macro\";
+
+dedent\`
+  \\n<p>
+    Hello world!
+  </p>\\n
+\`;
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+\"\\n<p>\\n  Hello world!\\n</p>\\n\";
+"
+`;
+
 exports[`expressions 1`] = `
 "
 import dedent from \"../macro\";

--- a/__tests__/__snapshots__/dedent-macro-test.js.snap
+++ b/__tests__/__snapshots__/dedent-macro-test.js.snap
@@ -29,17 +29,21 @@ dedent\`
 exports[`evaluated 1`] = `
 "
 import dedent from \"../macro\";
-import one from \"../external\";
+import { line, second } from \"../external\";
 
 dedent\`
-  1 + 1 = \${one + one}
+  first \${line}
+    \${second}
+    third
 \`;
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-import one from \"../external\";
+import { line, second } from \"../external\";
 
-\`1 + 1 = \${one + one}\`;
+\`first \${line}
+  \${second}
+  third\`;
 "
 `;
 

--- a/__tests__/__snapshots__/dedent-macro-test.js.snap
+++ b/__tests__/__snapshots__/dedent-macro-test.js.snap
@@ -26,6 +26,23 @@ dedent\`
 "
 `;
 
+exports[`evaluated 1`] = `
+"
+import dedent from \"../macro\";
+import one from \"../external\";
+
+dedent\`
+  1 + 1 = \${one + one}
+\`;
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import one from \"../external\";
+
+\`1 + 1 = \${one + one}\`;
+"
+`;
+
 exports[`explicit newline 1`] = `
 "
 import dedent from \"../macro\";

--- a/__tests__/dedent-macro-test.js
+++ b/__tests__/dedent-macro-test.js
@@ -66,10 +66,12 @@ pluginTester({
       title: "evaluated",
       code: `
         import dedent from "../macro";
-        import one from "../external";
+        import { line, second } from "../external";
 
         dedent\`
-          1 + 1 = \${one + one}
+          first \${line}
+            \${second}
+            third
         \`;
       `
     }

--- a/__tests__/dedent-macro-test.js
+++ b/__tests__/dedent-macro-test.js
@@ -61,6 +61,17 @@ pluginTester({
             third
         \`;
       `
+    },
+    {
+      title: "evaluated",
+      code: `
+        import dedent from "../macro";
+        import one from "../external";
+
+        dedent\`
+          1 + 1 = \${one + one}
+        \`;
+      `
     }
   ]
 });

--- a/__tests__/dedent-macro-test.js
+++ b/__tests__/dedent-macro-test.js
@@ -51,6 +51,18 @@ pluginTester({
       `
     },
     {
+      title: "explicit newlines",
+      code: `
+        import dedent from "../macro";
+
+        dedent\`
+          \\n<p>
+            Hello world!
+          </p>\\n
+        \`;
+      `
+    },
+    {
       title: "expressions",
       code: `
         import dedent from "../macro";

--- a/macro.js
+++ b/macro.js
@@ -21,13 +21,16 @@ function prevalMacros({ references, state, babel }) {
 
 function asTag(quasiPath, { file: { opts: { filename } } }, babel) {
   const { types: t } = babel;
-  const string = quasiPath.parentPath.get("quasi").evaluate().value;
-
-  // If evaluate succeeds (string != null), use string literal
+  
+  const originalQuasis = quasiPath.get('quasis').map(quasi => quasi.node);
+  const strings = { raw: originalQuasis.map(quasi => quasi.value.raw) };
+  const expressions = quasiPath.get('expressions').map(expression => expression.node);
+  
+  // If no expressions, use string literal
   // otherwise, use template literal
-  let replacement;
-  if (string != null) {
-    replacement = t.stringLiteral(dedent(string));
+  let replacement
+  if (!expressions.length) {
+    replacement = t.stringLiteral(dedent(strings));
   } else {
     const EXPRESSION = '---EXPR---';
 

--- a/macro.js
+++ b/macro.js
@@ -36,7 +36,7 @@ function asTag(quasiPath, { file: { opts: { filename } } }, babel) {
     
     const strings = { raw: originalQuasis.map(quasi => quasi.value.raw) };
     const placeholders = expressions.map(() => EXPRESSION);
-    const result = dedent(strings, placeholders);
+    const result = dedent.apply(dedent, [strings].concat(placeholders));
 
     const {types: t } = babel;
     const quasis = result.split(EXPRESSION).map((value, index) => {

--- a/macro.js
+++ b/macro.js
@@ -1,5 +1,5 @@
 const { createMacro, MacroError } = require("babel-plugin-macros");
-const dedent = require("./dedent.js").default;
+const dedent = require("./dist/dedent.js").default;
 
 module.exports = createMacro(prevalMacros);
 

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "dist/dedent.js",
   "files": [
     "dist/dedent.js",
+    "macro.js",
     "LICENSE"
   ],
   "repository": {


### PR DESCRIPTION
- Add `macro.js` to `files` so that it is published to npm
- Add fallback to macro for compiling into template literal when evaluate fails (e.g. external variables)