### PR TITLE
fix: add babel-plugin-add-module-exports

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,7 @@
 {
   "env": {
     "legacy": {
+      "plugins": [["add-module-exports", { "addDefaultProperty": true }]],
       "presets": [
         [
           "@babel/preset-env",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@babel/core": "^7.21.8",
     "@babel/plugin-transform-flow-comments": "^7.22.5",
     "@babel/preset-env": "^7.21.5",
+    "babel-plugin-add-module-exports": "^1.0.4",
     "babel-plugin-tester": "^11.0.4",
     "eslint": "^8.41.0",
     "eslint-plugin-ft-flow": "^2.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1526,6 +1526,11 @@ babel-jest@^29.5.0:
     graceful-fs "^4.2.9"
     slash "^3.0.0"
 
+babel-plugin-add-module-exports@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/babel-plugin-add-module-exports/-/babel-plugin-add-module-exports-1.0.4.tgz#6caa4ddbe1f578c6a5264d4d3e6c8a2720a7ca2b"
+  integrity sha512-g+8yxHUZ60RcyaUpfNzy56OtWW+x9cyEe9j+CranqLiqbju2yf/Cy6ZtYK40EZxtrdHllzlVZgLmcOUCTlJ7Jg==
+
 babel-plugin-istanbul@^6.1.1:
   version "6.1.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz#fa88ec59232fd9b4e36dbbc540a8ec9a9b47da73"


### PR DESCRIPTION
Fixes #39. Uses the plugin's [`addDefaultProperty`](https://www.npmjs.com/package/babel-plugin-add-module-exports#adddefaultproperty) so that both old and new behavior are preserved.

After a `yarn build` locally, the end of `dist/dedent.js` is:

```js
module.exports = exports.default;
module.exports.default = exports.default;
```