### PR TITLE
fix: update types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,1 +1,2 @@
-export default function dedent(strings: TemplateStringsArray, ...values: Array<string>): string;
+export default function dedent(literals: string): string;
+export default function dedent(strings: TemplateStringsArray, ...values: Array<any>): string;


### PR DESCRIPTION
Resolves #43

This matches the types in `@types/dedent` (which should now be removed from DT), and should make it easier to consume v1 while the rest of the repo is being improved.