### PR TITLE
feat: add options with escapeSpecialCharacters

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,62 @@ That's all.
 Wait! I lied. Dedent can also be used as a function.
 ```
 
+## Options
+
+You can customize the options `dedent` runs with by calling its `options` method with an object:
+
+<!-- prettier-ignore -->
+```js
+import dedent from 'dedent';
+
+dedent.options({ /* ... */ })`input`;
+dedent.options({ /* ... */ })(`input`);
+```
+
+`options` returns a new `dedent` function, so if you'd like to reuse the same options, you can create a dedicated `dedent` function:
+
+<!-- prettier-ignore -->
+```js
+import dedent from 'dedent';
+
+const dedenter = dedent({ /* ... */ });
+
+dedenter`input`;
+dedenter(`input`);
+```
+
+### `escapeSpecialCharacters`
+
+JavaScript string tags by default add an extra `\` escape in front of some special characters such as `$` dollar signs.
+`dedent` will escape those special characters when called as a string tag.
+
+If you'd like to change the behavior, an `escapeSpecialCharacters` option is available.
+It defaults to:
+
+- `false`: when `dedent` is called as a function
+- `true`: when `dedent` is called as a string tag
+
+```js
+import dedent from "dedent";
+
+// "$hello!"
+dedent`
+  $hello!
+`;
+
+// "\$hello!"
+dedent.options({ escapeSpecialCharacters: false })`
+  $hello!
+`;
+
+// "$hello!"
+dedent.options({ escapeSpecialCharacters: true })`
+  $hello!
+`;
+```
+
+For more context, see [https://github.com/dmnd/dedent/issues/63](🚀 Feature: Add an option to disable special character escaping).
+
 ## License
 
 MIT

--- a/README.md
+++ b/README.md
@@ -56,14 +56,14 @@ Wait! I lied. Dedent can also be used as a function.
 
 ## Options
 
-You can customize the options `dedent` runs with by calling its `options` method with an object:
+You can customize the options `dedent` runs with by calling its `withOptions` method with an object:
 
 <!-- prettier-ignore -->
 ```js
 import dedent from 'dedent';
 
-dedent.options({ /* ... */ })`input`;
-dedent.options({ /* ... */ })(`input`);
+dedent.withOptions({ /* ... */ })`input`;
+dedent.withOptions({ /* ... */ })(`input`);
 ```
 
 `options` returns a new `dedent` function, so if you'd like to reuse the same options, you can create a dedicated `dedent` function:
@@ -72,7 +72,7 @@ dedent.options({ /* ... */ })(`input`);
 ```js
 import dedent from 'dedent';
 
-const dedenter = dedent({ /* ... */ });
+const dedenter = dedent.withOptions({ /* ... */ });
 
 dedenter`input`;
 dedenter(`input`);
@@ -98,12 +98,12 @@ dedent`
 `;
 
 // "\$hello!"
-dedent.options({ escapeSpecialCharacters: false })`
+dedent.withOptions({ escapeSpecialCharacters: false })`
   $hello!
 `;
 
 // "$hello!"
-dedent.options({ escapeSpecialCharacters: true })`
+dedent.withOptions({ escapeSpecialCharacters: true })`
   $hello!
 `;
 ```

--- a/__tests__/__snapshots__/dedent-tests.ts.snap
+++ b/__tests__/__snapshots__/dedent-tests.ts.snap
@@ -2,31 +2,99 @@
 
 exports[`dedent can be used as a function 1`] = `"A test argument."`;
 
-exports[`dedent doesn't strip exlicit newlines 1`] = `
+exports[`dedent doesn't strip explicit newlines 1`] = `
 "<p>Hello world!</p>
 "
 `;
 
-exports[`dedent doesn't strip exlicit newlines with mindent 1`] = `
+exports[`dedent doesn't strip explicit newlines with mindent 1`] = `
 "<p>
   Hello world!
 </p>
 "
 `;
 
-exports[`dedent escapes backticks 1`] = `"\`"`;
+exports[`dedent function character escapes default behavior does not escape backticks 1`] = `"\`"`;
 
-exports[`dedent escapes dollar signs 1`] = `"$"`;
+exports[`dedent function character escapes default behavior does not escape dollar signs 1`] = `"$"`;
 
-exports[`dedent escapes opening braces 1`] = `"{"`;
+exports[`dedent function character escapes default behavior does not escape opening braces 1`] = `"{"`;
 
-exports[`dedent ignores closing braces 1`] = `"\\}"`;
+exports[`dedent function character escapes default behavior escapes double-escaped backticks 1`] = `"\\\`"`;
+
+exports[`dedent function character escapes default behavior escapes double-escaped dollar signs 1`] = `"\\$"`;
+
+exports[`dedent function character escapes default behavior escapes double-escaped opening braces 1`] = `"\\{"`;
+
+exports[`dedent function character escapes default behavior ignores closing braces 1`] = `"}"`;
+
+exports[`dedent function character escapes with escapeSpecialCharacters false backticks 1`] = `"\`"`;
+
+exports[`dedent function character escapes with escapeSpecialCharacters false dollar signs 1`] = `"$"`;
+
+exports[`dedent function character escapes with escapeSpecialCharacters false double-escaped backticks 1`] = `"\\\`"`;
+
+exports[`dedent function character escapes with escapeSpecialCharacters false double-escaped dollar signs 1`] = `"\\$"`;
+
+exports[`dedent function character escapes with escapeSpecialCharacters false double-escaped opening braces 1`] = `"\\{"`;
+
+exports[`dedent function character escapes with escapeSpecialCharacters false opening braces 1`] = `"{"`;
+
+exports[`dedent function character escapes with escapeSpecialCharacters true backticks 1`] = `"\`"`;
+
+exports[`dedent function character escapes with escapeSpecialCharacters true dollar signs 1`] = `"$"`;
+
+exports[`dedent function character escapes with escapeSpecialCharacters true double-escaped backticks 1`] = `"\`"`;
+
+exports[`dedent function character escapes with escapeSpecialCharacters true double-escaped dollar signs 1`] = `"$"`;
+
+exports[`dedent function character escapes with escapeSpecialCharacters true double-escaped opening braces 1`] = `"{"`;
+
+exports[`dedent function character escapes with escapeSpecialCharacters true opening braces 1`] = `"{"`;
+
+exports[`dedent function character escapes with escapeSpecialCharacters undefined backticks 1`] = `"\`"`;
+
+exports[`dedent function character escapes with escapeSpecialCharacters undefined dollar signs 1`] = `"$"`;
+
+exports[`dedent function character escapes with escapeSpecialCharacters undefined double-escaped backticks 1`] = `"\\\`"`;
+
+exports[`dedent function character escapes with escapeSpecialCharacters undefined double-escaped dollar signs 1`] = `"\\$"`;
+
+exports[`dedent function character escapes with escapeSpecialCharacters undefined double-escaped opening braces 1`] = `"\\{"`;
+
+exports[`dedent function character escapes with escapeSpecialCharacters undefined opening braces 1`] = `"{"`;
 
 exports[`dedent single line input works with single line and closing backtick on newline 1`] = `"A single line of input."`;
 
 exports[`dedent single line input works with single line and inline closing backtick 1`] = `"A single line of input."`;
 
 exports[`dedent single line input works with single line input 1`] = `"A single line of input."`;
+
+exports[`dedent string tag character escapes default behavior escapes backticks 1`] = `"\`"`;
+
+exports[`dedent string tag character escapes default behavior escapes dollar signs 1`] = `"$"`;
+
+exports[`dedent string tag character escapes default behavior escapes opening braces 1`] = `"{"`;
+
+exports[`dedent string tag character escapes default behavior ignores closing braces 1`] = `"\\}"`;
+
+exports[`dedent string tag character escapes with escapeSpecialCharacters false backticks 1`] = `"\\\`"`;
+
+exports[`dedent string tag character escapes with escapeSpecialCharacters false dollar signs 1`] = `"\\$"`;
+
+exports[`dedent string tag character escapes with escapeSpecialCharacters false opening braces 1`] = `"\\{"`;
+
+exports[`dedent string tag character escapes with escapeSpecialCharacters true backticks 1`] = `"\`"`;
+
+exports[`dedent string tag character escapes with escapeSpecialCharacters true dollar signs 1`] = `"$"`;
+
+exports[`dedent string tag character escapes with escapeSpecialCharacters true opening braces 1`] = `"{"`;
+
+exports[`dedent string tag character escapes with escapeSpecialCharacters undefined backticks 1`] = `"\`"`;
+
+exports[`dedent string tag character escapes with escapeSpecialCharacters undefined dollar signs 1`] = `"$"`;
+
+exports[`dedent string tag character escapes with escapeSpecialCharacters undefined opening braces 1`] = `"{"`;
 
 exports[`dedent works with blank first line 1`] = `
 "Some text that I might want to indent:

--- a/__tests__/dedent-tests.ts
+++ b/__tests__/dedent-tests.ts
@@ -1,9 +1,9 @@
-import dd from "../dedent";
+import dedent from "../dedent";
 
 describe("dedent", () => {
   it("works without interpolation", () => {
     expect(
-      dd`first
+      dedent`first
          second
          third`
     ).toMatchSnapshot();
@@ -11,7 +11,7 @@ describe("dedent", () => {
 
   it("works with interpolation", () => {
     expect(
-      dd`first ${"line"}
+      dedent`first ${"line"}
          ${"second"}
          third`
     ).toMatchSnapshot();
@@ -19,14 +19,14 @@ describe("dedent", () => {
 
   it("works with suppressed newlines", () => {
     expect(
-      dd`first \
+      dedent`first \
          ${"second"}
          third`
     ).toMatchSnapshot();
   });
 
   it("works with blank first line", () => {
-    expect(dd`
+    expect(dedent`
       Some text that I might want to indent:
         * reasons
         * fun
@@ -36,7 +36,7 @@ describe("dedent", () => {
 
   it("works with multiple blank first lines", () => {
     expect(
-      dd`
+      dedent`
 
          first
          second
@@ -46,7 +46,7 @@ describe("dedent", () => {
 
   it("works with removing same number of spaces", () => {
     expect(
-      dd`
+      dedent`
          first
             second
                third
@@ -56,53 +56,153 @@ describe("dedent", () => {
 
   describe("single line input", () => {
     it("works with single line input", () => {
-      expect(dd`A single line of input.`).toMatchSnapshot();
+      expect(dedent`A single line of input.`).toMatchSnapshot();
     });
 
     it("works with single line and closing backtick on newline", () => {
-      expect(dd`
+      expect(dedent`
         A single line of input.
       `).toMatchSnapshot();
     });
 
     it("works with single line and inline closing backtick", () => {
-      expect(dd`
+      expect(dedent`
         A single line of input.`).toMatchSnapshot();
     });
   });
 
   it("can be used as a function", () => {
     expect(
-      dd(`
+      dedent(`
       A test argument.
     `)
     ).toMatchSnapshot();
   });
 
-  it("escapes backticks", () => {
-    expect(dd`\``).toMatchSnapshot();
+  describe("function character escapes", () => {
+    describe("default behavior", () => {
+      it("does not escape backticks", () => {
+        expect(dedent(`\``)).toMatchSnapshot();
+      });
+
+      it("does not escape dollar signs", () => {
+        expect(dedent(`$`)).toMatchSnapshot();
+      });
+
+      it("does not escape opening braces", () => {
+        expect(dedent(`{`)).toMatchSnapshot();
+      });
+
+      it("escapes double-escaped backticks", () => {
+        expect(dedent(`\\\``)).toMatchSnapshot();
+      });
+
+      it("escapes double-escaped dollar signs", () => {
+        expect(dedent(`\\$`)).toMatchSnapshot();
+      });
+
+      it("escapes double-escaped opening braces", () => {
+        expect(dedent(`\\{`)).toMatchSnapshot();
+      });
+
+      it("ignores closing braces", () => {
+        expect(dedent(`}`)).toMatchSnapshot();
+      });
+    });
+
+    describe.each([undefined, false, true])(
+      "with escapeSpecialCharacters %s",
+      (escapeSpecialCharacters) => {
+        test("backticks", () => {
+          expect(
+            dedent.options({ escapeSpecialCharacters })(`\``)
+          ).toMatchSnapshot();
+        });
+
+        test("dollar signs", () => {
+          expect(
+            dedent.options({ escapeSpecialCharacters })(`$`)
+          ).toMatchSnapshot();
+        });
+
+        test("opening braces", () => {
+          expect(
+            dedent.options({ escapeSpecialCharacters })(`{`)
+          ).toMatchSnapshot();
+        });
+
+        test("double-escaped backticks", () => {
+          expect(
+            dedent.options({ escapeSpecialCharacters })(`\\\``)
+          ).toMatchSnapshot();
+        });
+
+        test("double-escaped dollar signs", () => {
+          expect(
+            dedent.options({ escapeSpecialCharacters })(`\\$`)
+          ).toMatchSnapshot();
+        });
+
+        test("double-escaped opening braces", () => {
+          expect(
+            dedent.options({ escapeSpecialCharacters })(`\\{`)
+          ).toMatchSnapshot();
+        });
+      }
+    );
   });
 
-  it("escapes dollar signs", () => {
-    expect(dd`\$`).toMatchSnapshot();
+  describe("string tag character escapes", () => {
+    describe("default behavior", () => {
+      it("escapes backticks", () => {
+        expect(dedent`\``).toMatchSnapshot();
+      });
+
+      it("escapes dollar signs", () => {
+        expect(dedent`\$`).toMatchSnapshot();
+      });
+
+      it("escapes opening braces", () => {
+        expect(dedent`\{`).toMatchSnapshot();
+      });
+
+      it("ignores closing braces", () => {
+        expect(dedent`\}`).toMatchSnapshot();
+      });
+    });
+
+    describe.each([undefined, false, true])(
+      "with escapeSpecialCharacters %s",
+      (escapeSpecialCharacters) => {
+        test("backticks", () => {
+          expect(
+            dedent.options({ escapeSpecialCharacters })`\``
+          ).toMatchSnapshot();
+        });
+
+        test("dollar signs", () => {
+          expect(
+            dedent.options({ escapeSpecialCharacters })`\$`
+          ).toMatchSnapshot();
+        });
+
+        test("opening braces", () => {
+          expect(
+            dedent.options({ escapeSpecialCharacters })`\{`
+          ).toMatchSnapshot();
+        });
+      }
+    );
   });
 
-  it("escapes opening braces", () => {
-    expect(dd`\{`).toMatchSnapshot();
-  });
-
-  it("ignores closing braces", () => {
-    expect(dd`\}`).toMatchSnapshot();
-  });
-
-  it("doesn't strip exlicit newlines", () => {
-    expect(dd`
+  it("doesn't strip explicit newlines", () => {
+    expect(dedent`
       <p>Hello world!</p>\n
     `).toMatchSnapshot();
   });
 
-  it("doesn't strip exlicit newlines with mindent", () => {
-    expect(dd`
+  it("doesn't strip explicit newlines with mindent", () => {
+    expect(dedent`
       <p>
         Hello world!
       </p>\n
@@ -112,7 +212,7 @@ describe("dedent", () => {
   /* eslint-disable indent */
   it("works with tabs for indentation", () => {
     expect(
-      dd`
+      dedent`
 			first
 				second
 					third
@@ -121,7 +221,7 @@ describe("dedent", () => {
   });
 
   it("works with escaped tabs for indentation", () => {
-    expect(dd("\t\tfirst\n\t\t\tsecond\n\t\t\t\tthird")).toMatchSnapshot();
+    expect(dedent("\t\tfirst\n\t\t\tsecond\n\t\t\t\tthird")).toMatchSnapshot();
   });
   /* eslint-enable indent */
 });

--- a/__tests__/dedent-tests.ts
+++ b/__tests__/dedent-tests.ts
@@ -115,37 +115,37 @@ describe("dedent", () => {
       (escapeSpecialCharacters) => {
         test("backticks", () => {
           expect(
-            dedent.options({ escapeSpecialCharacters })(`\``)
+            dedent.withOptions({ escapeSpecialCharacters })(`\``)
           ).toMatchSnapshot();
         });
 
         test("dollar signs", () => {
           expect(
-            dedent.options({ escapeSpecialCharacters })(`$`)
+            dedent.withOptions({ escapeSpecialCharacters })(`$`)
           ).toMatchSnapshot();
         });
 
         test("opening braces", () => {
           expect(
-            dedent.options({ escapeSpecialCharacters })(`{`)
+            dedent.withOptions({ escapeSpecialCharacters })(`{`)
           ).toMatchSnapshot();
         });
 
         test("double-escaped backticks", () => {
           expect(
-            dedent.options({ escapeSpecialCharacters })(`\\\``)
+            dedent.withOptions({ escapeSpecialCharacters })(`\\\``)
           ).toMatchSnapshot();
         });
 
         test("double-escaped dollar signs", () => {
           expect(
-            dedent.options({ escapeSpecialCharacters })(`\\$`)
+            dedent.withOptions({ escapeSpecialCharacters })(`\\$`)
           ).toMatchSnapshot();
         });
 
         test("double-escaped opening braces", () => {
           expect(
-            dedent.options({ escapeSpecialCharacters })(`\\{`)
+            dedent.withOptions({ escapeSpecialCharacters })(`\\{`)
           ).toMatchSnapshot();
         });
       }
@@ -176,19 +176,19 @@ describe("dedent", () => {
       (escapeSpecialCharacters) => {
         test("backticks", () => {
           expect(
-            dedent.options({ escapeSpecialCharacters })`\``
+            dedent.withOptions({ escapeSpecialCharacters })`\``
           ).toMatchSnapshot();
         });
 
         test("dollar signs", () => {
           expect(
-            dedent.options({ escapeSpecialCharacters })`\$`
+            dedent.withOptions({ escapeSpecialCharacters })`\$`
           ).toMatchSnapshot();
         });
 
         test("opening braces", () => {
           expect(
-            dedent.options({ escapeSpecialCharacters })`\{`
+            dedent.withOptions({ escapeSpecialCharacters })`\{`
           ).toMatchSnapshot();
         });
       }

--- a/dedent.ts
+++ b/dedent.ts
@@ -1,60 +1,77 @@
-export default function dedent(literals: string): string;
-export default function dedent(
-  strings: TemplateStringsArray,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  ...values: any[]
-): string;
-export default function dedent(
-  strings: string | TemplateStringsArray,
-  ...values: string[]
-) {
-  const raw = typeof strings === "string" ? [strings] : strings.raw;
+import { DedentOptions } from "./types";
 
-  // first, perform interpolation
-  let result = "";
-  for (let i = 0; i < raw.length; i++) {
-    result += raw[i]
-      // handle escaped newlines, backticks, and interpolation characters
-      .replace(/\\`/g, "`")
-      .replace(/\\\n[ \t]*/g, "")
-      .replace(/\\\$/g, "$")
-      .replace(/\\{/g, "{");
+export * from "./types";
 
-    if (i < values.length) {
-      result += values[i];
-    }
-  }
+export default createDedent({});
 
-  // now strip indentation
-  const lines = result.split("\n");
-  let mindent: number | null = null;
-  for (const l of lines) {
-    const m = l.match(/^(\s+)\S+/);
-    if (m) {
-      const indent = m[1].length;
-      if (!mindent) {
-        // this is the first indented line
-        mindent = indent;
-      } else {
-        mindent = Math.min(mindent, indent);
+function createDedent(options: DedentOptions) {
+  dedent.options = (newOptions: DedentOptions) =>
+    createDedent({ ...options, ...newOptions });
+
+  return dedent;
+
+  function dedent(literals: string): string;
+  function dedent(strings: TemplateStringsArray, ...values: unknown[]): string;
+  function dedent(
+    strings: string | TemplateStringsArray,
+    ...values: unknown[]
+  ) {
+    const raw = typeof strings === "string" ? [strings] : strings.raw;
+    const { escapeSpecialCharacters = Array.isArray(strings) } = options;
+
+    // first, perform interpolation
+    let result = "";
+    for (let i = 0; i < raw.length; i++) {
+      let next = raw[i];
+
+      if (escapeSpecialCharacters) {
+        // handle escaped newlines, backticks, and interpolation characters
+        next = next
+          .replace(/\\\n[ \t]*/g, "")
+          .replace(/\\`/g, "`")
+          .replace(/\\\$/g, "$")
+          .replace(/\\{/g, "{");
+      }
+
+      result += next;
+
+      if (i < values.length) {
+        // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
+        result += values[i];
       }
     }
-  }
 
-  if (mindent !== null) {
-    const m = mindent; // appease TypeScript
-    result = lines
-      // https://github.com/typescript-eslint/typescript-eslint/issues/7140
-      // eslint-disable-next-line @typescript-eslint/prefer-string-starts-ends-with
-      .map((l) => (l[0] === " " || l[0] === "\t" ? l.slice(m) : l))
-      .join("\n");
-  }
+    // now strip indentation
+    const lines = result.split("\n");
+    let mindent: number | null = null;
+    for (const l of lines) {
+      const m = l.match(/^(\s+)\S+/);
+      if (m) {
+        const indent = m[1].length;
+        if (!mindent) {
+          // this is the first indented line
+          mindent = indent;
+        } else {
+          mindent = Math.min(mindent, indent);
+        }
+      }
+    }
 
-  return (
-    result
-      // dedent eats leading and trailing whitespace too
-      .trim()
-      // handle escaped newlines at the end to ensure they don't get stripped too
-      .replace(/\\n/g, "\n")
-  );
+    if (mindent !== null) {
+      const m = mindent; // appease TypeScript
+      result = lines
+        // https://github.com/typescript-eslint/typescript-eslint/issues/7140
+        // eslint-disable-next-line @typescript-eslint/prefer-string-starts-ends-with
+        .map((l) => (l[0] === " " || l[0] === "\t" ? l.slice(m) : l))
+        .join("\n");
+    }
+
+    return (
+      result
+        // dedent eats leading and trailing whitespace too
+        .trim()
+        // handle escaped newlines at the end to ensure they don't get stripped too
+        .replace(/\\n/g, "\n")
+    );
+  }
 }

--- a/dedent.ts
+++ b/dedent.ts
@@ -1,11 +1,11 @@
-import { DedentOptions } from "./types";
+import type { DedentOptions } from "./types";
 
-export * from "./types";
+export type * from "./types";
 
 export default createDedent({});
 
 function createDedent(options: DedentOptions) {
-  dedent.options = (newOptions: DedentOptions) =>
+  dedent.withOptions = (newOptions: DedentOptions) =>
     createDedent({ ...options, ...newOptions });
 
   return dedent;

--- a/types.ts
+++ b/types.ts
@@ -1,0 +1,11 @@
+export interface DedentOptions {
+  escapeSpecialCharacters?: boolean;
+}
+
+export interface Dedent {
+  (literals: string): string;
+  (strings: TemplateStringsArray, ...values: unknown[]): string;
+  options: CreateDedent;
+}
+
+export type CreateDedent = (options: DedentOptions) => Dedent;

--- a/types.ts
+++ b/types.ts
@@ -5,7 +5,7 @@ export interface DedentOptions {
 export interface Dedent {
   (literals: string): string;
   (strings: TemplateStringsArray, ...values: unknown[]): string;
-  options: CreateDedent;
+  withOptions: CreateDedent;
 }
 
 export type CreateDedent = (options: DedentOptions) => Dedent;


### PR DESCRIPTION
Fixes #26. Fixes #63.

As described in #63, this introduces the concept of options with single option, `escapeSpecialCharacters`. The option defaults to:

* `true` when called for a template literal's string tag
* `false` when called as a function

```js
// "\$hello!"
dedent.options({ escapeSpecialCharacters: false })`
  $hello!
`;
```

I'd played with allowing passing it in as a first argument instead of a string or template literal strings array, but that got complex. I suppose we can do that as a followup if people really want.

cc @G-Rath @sirian - what do you think? 