### PR TITLE
fix: fix missing ESM type definition file

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,9 +7,14 @@
   "module": "./dist/dedent.mjs",
   "exports": {
     ".": {
-      "types": "./dist/dedent.d.ts",
-      "import": "./dist/dedent.mjs",
-      "default": "./dist/dedent.js"
+      "import": {
+        "types": "./dist/dedent.d.mts",
+        "default": "./dist/dedent.mjs"
+      },
+      "require": {
+        "types": "./dist/dedent.d.ts",
+        "default": "./dist/dedent.js"
+      }
     }
   },
   "files": [
@@ -72,7 +77,7 @@
     "build": "yarn build:legacy && yarn build:modern && yarn build:types",
     "build:legacy": "BABEL_ENV=legacy babel dedent.ts --out-file dist/dedent.js",
     "build:modern": "BABEL_ENV=modern babel dedent.ts --out-file dist/dedent.mjs",
-    "build:types": "tsup dedent.ts --dts-only",
+    "build:types": "tsup dedent.ts --dts-only --format cjs,esm",
     "lint": "eslint .",
     "prepack": "yarn build",
     "test": "jest",


### PR DESCRIPTION
## Background

The dedent package exports only CJS type definition files (`./dist/index.d.ts`). Therefore, if users try to import dedent as an ESM, `tsc` will not find the type definition file.

How to reproduction:

```console
$ git clone https://github.com/mizdra/reproduction-dedent-fix-missing-esm-type-definition
$ cd reproduction-dedent-fix-missing-esm-type-definition
$ npm i
$ npm run build

> app_name@0.0.0 build
> tsc -p tsconfig.build.json

src/index.ts:5:15 - error TS2349: This expression is not callable.
  Type 'typeof import("/Users/mizdra/src/github.com/mizdra/reproduction-dedent-fix-missing-esm-type-definition/node_modules/dedent/dist/dedent")' has no call signatures.

5   console.log(dedent`text`);
                ~~~~~~


Found 1 error in src/index.ts:5
```

`src/index.ts`:
```ts
import dedent from 'dedent';

export function run() {
  // eslint-disable-next-line no-console
  console.log(dedent`text`);
}
```

This problem can also be detected by publint.

- https://publint.dev/dedent@1.3.0

## Solution

To solve this problem, I added the ESM type definition file (`./dist/dedent.d.mts`).

I have also confirmed that this patch allows `tsc` to pass.
```console
$ npm i -S ../dedent
$ npm run build

> app_name@0.0.0 build
> tsc -p tsconfig.build.json

$ echo $?
0
```

