### PR TITLE
chore: fix special characters escaping issue link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ dedent.withOptions({ escapeSpecialCharacters: true })`
 `;
 ```
 
-For more context, see [https://github.com/dmnd/dedent/issues/63](🚀 Feature: Add an option to disable special character escaping).
+For more context, see [🚀 Feature: Add an option to disable special character escaping](https://github.com/dmnd/dedent/issues/63).
 
 ## License
 


### PR DESCRIPTION
## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/dmnd/dedent/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/dmnd/dedent/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

I don't think it should look like this :)
![image](https://github.com/dmnd/dedent/assets/61150013/047dbb21-2b0f-40cf-b09b-b29d6e0e4510)
