### PR TITLE
chore: replace last yarn references with pnpm

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
 		"README.md"
 	],
 	"scripts": {
-		"build": "yarn build:legacy && yarn build:modern && yarn build:types",
+		"build": "pnpm build:legacy && pnpm build:modern && pnpm build:types",
 		"build:legacy": "BABEL_ENV=legacy babel src/dedent.ts --out-file dist/dedent.js",
 		"build:modern": "BABEL_ENV=modern babel src/dedent.ts --out-file dist/dedent.mjs",
 		"build:types": "tsup src/dedent.ts --dts-only",


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #85
- [x] That issue was marked as [`status: accepting prs`](https://github.com/dmnd/dedent/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/dmnd/dedent/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Fixes the last few `yarn` references in `package.json` scripts to instead say `pnpm`.