### PR TITLE
fix: \\n should be changed to \n only when escapeSpecialCharacters is set

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "dedent",
-	"version": "1.5.1",
+	"version": "1.5.2",
 	"description": "A string tag that strips indentation from multi-line strings. ⬅️",
 	"keywords": [
 		"dedent",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "dedent",
-	"version": "1.5.2",
+	"version": "1.5.1",
 	"description": "A string tag that strips indentation from multi-line strings. ⬅️",
 	"keywords": [
 		"dedent",

--- a/src/dedent.test.ts
+++ b/src/dedent.test.ts
@@ -232,4 +232,8 @@ describe("dedent", () => {
 	it("works with escaped tabs for indentation", () => {
 		expect(dedent("\t\tfirst\n\t\t\tsecond\n\t\t\t\tthird")).toMatchSnapshot();
 	});
+
+	it("does not replace \\n when called as a function", () => {
+		expect(dedent(`\\nu`)).toBe("\\nu");
+	});
 });

--- a/src/dedent.ts
+++ b/src/dedent.ts
@@ -68,12 +68,13 @@ function createDedent(options: DedentOptions) {
 				.join("\n");
 		}
 
-		return (
-			result
-				// dedent eats leading and trailing whitespace too
-				.trim()
-				// handle escaped newlines at the end to ensure they don't get stripped too
-				.replace(/\\n/g, "\n")
-		);
+		// dedent eats leading and trailing whitespace too
+		result = result.trim();
+		if (escapeSpecialCharacters) {
+			// handle escaped newlines at the end to ensure they don't get stripped too
+			result = result.replace(/\\n/g, "\n");
+		}
+
+		return result;
 	}
 }


### PR DESCRIPTION
This PR proposes a fix to the issue #90.

## PR Checklist

- [x] Addresses an existing open issue: fixes #90
- [x] That issue was marked as [`status: accepting prs`](https://github.com/dmnd/dedent/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/dmnd/dedent/blob/main/.github/CONTRIBUTING.md) were taken

