### PR TITLE
feat: add `trimWhitespace` option

### DIFF
--- a/src/__snapshots__/dedent.test.ts.snap
+++ b/src/__snapshots__/dedent.test.ts.snap
@@ -96,6 +96,52 @@ exports[`dedent string tag character escapes with escapeSpecialCharacters undefi
 
 exports[`dedent string tag character escapes with escapeSpecialCharacters undefined opening braces 1`] = `"{"`;
 
+exports[`dedent with trimWhitespace false with leading whitespace 1`] = `
+"
+
+
+foo
+"
+`;
+
+exports[`dedent with trimWhitespace false with trailing whitespace 1`] = `
+"
+foo   
+bar   
+"
+`;
+
+exports[`dedent with trimWhitespace false without trailing whitespace 1`] = `
+"
+foo
+bar
+"
+`;
+
+exports[`dedent with trimWhitespace true with leading whitespace 1`] = `"foo"`;
+
+exports[`dedent with trimWhitespace true with trailing whitespace 1`] = `
+"foo   
+bar"
+`;
+
+exports[`dedent with trimWhitespace true without trailing whitespace 1`] = `
+"foo
+bar"
+`;
+
+exports[`dedent with trimWhitespace undefined with leading whitespace 1`] = `"foo"`;
+
+exports[`dedent with trimWhitespace undefined with trailing whitespace 1`] = `
+"foo   
+bar"
+`;
+
+exports[`dedent with trimWhitespace undefined without trailing whitespace 1`] = `
+"foo
+bar"
+`;
+
 exports[`dedent works with blank first line 1`] = `
 "Some text that I might want to indent:
 	* reasons
@@ -129,8 +175,8 @@ exports[`dedent works with removing same number of spaces 1`] = `
 
 exports[`dedent works with spaces for indentation 1`] = `
 "first
-  second
-    third"
+	second
+		third"
 `;
 
 exports[`dedent works with suppressed newlines 1`] = `

--- a/src/dedent.test.ts
+++ b/src/dedent.test.ts
@@ -152,6 +152,43 @@ describe("dedent", () => {
 		);
 	});
 
+	describe.each([undefined, false, true])(
+		"with trimWhitespace %s",
+		(trimWhitespace) => {
+			test("with trailing whitespace", () => {
+				expect(
+					dedent.withOptions({ trimWhitespace })(
+						`
+						foo---
+						bar---
+					`.replace(/-/g, " "),
+					),
+				).toMatchSnapshot();
+			});
+
+			test("without trailing whitespace", () => {
+				expect(
+					dedent.withOptions({ trimWhitespace })(
+						`
+						foo
+						bar
+					`.replace(/-/g, " "),
+					),
+				).toMatchSnapshot();
+			});
+
+			test("with leading whitespace", () => {
+				expect(
+					dedent.withOptions({ trimWhitespace })(`
+
+
+						foo
+					`),
+				).toMatchSnapshot();
+			});
+		},
+	);
+
 	describe("string tag character escapes", () => {
 		describe("default behavior", () => {
 			it("escapes backticks", () => {
@@ -212,10 +249,10 @@ describe("dedent", () => {
 	it("works with spaces for indentation", () => {
 		expect(
 			dedent`
-      first
-        second
-          third
-      `,
+			first
+				second
+					third
+			`,
 		).toMatchSnapshot();
 	});
 

--- a/src/dedent.ts
+++ b/src/dedent.ts
@@ -19,7 +19,10 @@ function createDedent(options: DedentOptions) {
 		...values: unknown[]
 	) {
 		const raw = typeof strings === "string" ? [strings] : strings.raw;
-		const { escapeSpecialCharacters = Array.isArray(strings) } = options;
+		const {
+			escapeSpecialCharacters = Array.isArray(strings),
+			trimWhitespace: stripTrailingWhitespace = true,
+		} = options;
 
 		// first, perform interpolation
 		let result = "";
@@ -69,7 +72,9 @@ function createDedent(options: DedentOptions) {
 		}
 
 		// dedent eats leading and trailing whitespace too
-		result = result.trim();
+		if (stripTrailingWhitespace) {
+			result = result.trim();
+		}
 		if (escapeSpecialCharacters) {
 			// handle escaped newlines at the end to ensure they don't get stripped too
 			result = result.replace(/\\n/g, "\n");

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,6 @@
 export interface DedentOptions {
 	escapeSpecialCharacters?: boolean;
+	trimWhitespace?: boolean;
 }
 
 export interface Dedent {


### PR DESCRIPTION
Adds a `trimWhitespace` option which decides if we trim the leading and trailing whitespace of the result.

## PR Checklist

- [x] Addresses an existing open issue: fixes #96 
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/dmnd/dedent/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/dmnd/dedent/blob/main/.github/CONTRIBUTING.md) were taken