### PR TITLE
fix: workaround for bun mangling unicode

### DIFF
--- a/.github/DEVELOPMENT.md
+++ b/.github/DEVELOPMENT.md
@@ -78,6 +78,14 @@ pnpm run test --coverage
 Note that [console-fail-test](https://github.com/JoshuaKGoldberg/console-fail-test) is enabled for all test runs.
 Calls to `console.log`, `console.warn`, and other console methods will cause a test to fail.
 
+### Testing with Bun
+
+With Bun installed on your system, the tests can be ran with [Bun](https://bun.com/docs/test)'s test runner rather than Node and Jest.
+
+```shell
+pnpm run test:bun
+```
+
 ## Type Checking
 
 You should be able to see suggestions from [TypeScript](https://typescriptlang.org) in your editor for all open files.

--- a/.github/DEVELOPMENT.md
+++ b/.github/DEVELOPMENT.md
@@ -80,7 +80,7 @@ Calls to `console.log`, `console.warn`, and other console methods will cause a t
 
 ### Testing with Bun
 
-With Bun installed on your system, the tests can be ran with [Bun](https://bun.com/docs/test)'s test runner rather than Node and Jest.
+If you have [Bun](https://bun.com/docs/test) installed on your system, tests can be run with Bun's test runner rather than Node and Jest.
 
 ```shell
 pnpm run test:bun

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://unpkg.com/knip@latest/schema.json",
 	"entry": ["src/index.ts!"],
-	"ignoreDependencies": ["babel-plugin-macros"],
+	"ignoreDependencies": ["babel-plugin-macros", "@types/bun"],
 	"ignoreExportsUsedInFile": { "interface": true, "type": true },
 	"project": ["src/**/*.ts!"]
 }

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
 		"prepare": "husky install",
 		"should-semantic-release": "should-semantic-release --verbose",
 		"test": "jest",
+		"test:bun": "bun test src/dedent.test.ts",
 		"tsc": "tsc"
 	},
 	"lint-staged": {
@@ -69,6 +70,7 @@
 		"@babel/preset-typescript": "^7.23.3",
 		"@release-it/conventional-changelog": "^8.0.1",
 		"@types/babel-plugin-macros": "^3.1.0",
+		"@types/bun": "^1.3.4",
 		"@types/eslint": "^8.44.7",
 		"@types/jest": "^29.5.3",
 		"@typescript-eslint/eslint-plugin": "^6.10.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,6 +25,9 @@ devDependencies:
   '@types/babel-plugin-macros':
     specifier: ^3.1.0
     version: 3.1.0
+  '@types/bun':
+    specifier: ^1.3.4
+    version: 1.3.4
   '@types/eslint':
     specifier: ^8.44.7
     version: 8.44.7
@@ -2671,6 +2674,12 @@ packages:
       '@babel/types': 7.23.6
     dev: true
 
+  /@types/bun@1.3.4:
+    resolution: {integrity: sha512-EEPTKXHP+zKGPkhRLv+HI0UEX8/o+65hqARxLy8Ov5rIxMBPNTjeZww00CIihrIQGEQBYg+0roO5qOnS/7boGA==}
+    dependencies:
+      bun-types: 1.3.4
+    dev: true
+
   /@types/eslint@8.44.7:
     resolution: {integrity: sha512-f5ORu2hcBbKei97U73mf+l9t4zTGl74IqZ0GQk4oVea/VS8tQZYkUveSYojk+frraAVYId0V2WC9O4PTNru2FQ==}
     dependencies:
@@ -3466,6 +3475,12 @@ packages:
     resolution: {integrity: sha512-qwVpFEHNfhYJIzNRBvd2C1kyo6jz3ZSMPyyuR47OPdiKWlbYnZNyDWuyR175qDnAJLiCo5fBBqPb3RiXgWlkOQ==}
     dependencies:
       semver: 7.5.4
+    dev: true
+
+  /bun-types@1.3.4:
+    resolution: {integrity: sha512-5ua817+BZPZOlNaRgGBpZJOSAQ9RQ17pkwPD0yR7CfJg+r8DgIILByFifDTa+IPDDxzf5VNhtNlcKqFzDgJvlQ==}
+    dependencies:
+      '@types/node': 20.4.2
     dev: true
 
   /bundle-name@3.0.0:

--- a/src/dedent.test.ts
+++ b/src/dedent.test.ts
@@ -296,9 +296,12 @@ describe("dedent", () => {
 		},
 	);
 
-	describe("bun environment tests", () => {
-		it("preserves unicode", () => {
+	describe("Unicode character preservation", () => {
+		it("preserves emojis", () => {
 			expect(dedent`😊`).toBe("😊");
+		});
+
+		it("preserves ideographs", () => {
 			expect(dedent`弟気`).toBe("弟気");
 		});
 	});

--- a/src/dedent.test.ts
+++ b/src/dedent.test.ts
@@ -295,4 +295,11 @@ describe("dedent", () => {
 			});
 		},
 	);
+
+	describe("bun environment tests", () => {
+		it("preserves unicode", () => {
+			expect(dedent`😊`).toBe("😊");
+			expect(dedent`弟気`).toBe("弟気");
+		});
+	});
 });

--- a/src/dedent.ts
+++ b/src/dedent.ts
@@ -84,6 +84,19 @@ function createDedent(options: DedentOptions) {
 			result = result.replace(/\\n/g, "\n");
 		}
 
+		// Workaround for Bun issue with Unicode characters
+		// https://github.com/oven-sh/bun/issues/8745
+		if (typeof Bun !== "undefined") {
+			result = result.replace(
+				// Matches e.g. \\u{1f60a} or \\u5F1F
+				/\\u(?:\{([\da-fA-F]{1,6})\}|([\da-fA-F]{4}))/g,
+				(_, braced?: string, unbraced?: string) => {
+					const hex = braced ?? unbraced ?? "";
+					return String.fromCodePoint(parseInt(hex, 16));
+				},
+			);
+		}
+
 		return result;
 	}
 }


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to dedent! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #101
- [x] That issue was marked as [`status: accepting prs`](https://github.com/dmnd/dedent/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/dmnd/dedent/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

- Adds a workaround to restore unicode characters mangled by Bun with a string replacement. This replacement runs only in a Bun environment. If the issue gets fixed in Bun, then a test for the version of `process.versions.bun` could perhaps be added later.
- Adds types for Bun, needed for that environment check to lint.
- Adds `test:bun` as a script, so that `pnpm run test:bun` will test decent.test.js with Bun's test runner instead of Jest, as long as Bun is installed. Includes a note in DEVELOPING.md.
- Adds a test which failed before the change with Bun (but passed with Node/Jest). 