### PR TITLE
fix: support escape sequences in tagged templates

### DIFF
--- a/src/__snapshots__/dedent.test.ts.snap
+++ b/src/__snapshots__/dedent.test.ts.snap
@@ -64,6 +64,15 @@ exports[`dedent function character escapes with escapeSpecialCharacters undefine
 
 exports[`dedent function character escapes with escapeSpecialCharacters undefined opening braces 1`] = `"{"`;
 
+exports[`dedent should escape when called with template strings (multiline) 1`] = `
+"\${hi}
+name"
+`;
+
+exports[`dedent should escape when called with template strings 1`] = `"a b"`;
+
+exports[`dedent should escape when called with template strings 2`] = `"\${hi}"`;
+
 exports[`dedent single line input works with single line and closing backtick on newline 1`] = `"A single line of input."`;
 
 exports[`dedent single line input works with single line and inline closing backtick 1`] = `"A single line of input."`;

--- a/src/__snapshots__/dedent.test.ts.snap
+++ b/src/__snapshots__/dedent.test.ts.snap
@@ -64,14 +64,14 @@ exports[`dedent function character escapes with escapeSpecialCharacters undefine
 
 exports[`dedent function character escapes with escapeSpecialCharacters undefined opening braces 1`] = `"{"`;
 
+exports[`dedent should escape when called with template strings (escaped interpolation) 1`] = `"\${hi}"`;
+
+exports[`dedent should escape when called with template strings (hex escape) 1`] = `"a b"`;
+
 exports[`dedent should escape when called with template strings (multiline) 1`] = `
 "\${hi}
 name"
 `;
-
-exports[`dedent should escape when called with template strings 1`] = `"a b"`;
-
-exports[`dedent should escape when called with template strings 2`] = `"\${hi}"`;
 
 exports[`dedent single line input works with single line and closing backtick on newline 1`] = `"A single line of input."`;
 

--- a/src/dedent.test.ts
+++ b/src/dedent.test.ts
@@ -274,6 +274,37 @@ describe("dedent", () => {
 		expect(dedent(`\\nu`)).toBe("\\nu");
 	});
 
+	it("handles escape sequences like hex and unicode", () => {
+		expect(dedent`\xa0\t`).toBe("\xa0\t");
+		expect(dedent`\u5F1F`).toBe("\u5F1F");
+		expect(dedent`\u{1F60A}`).toBe("\u{1F60A}");
+	});
+
+	it("does not unescape when escapeSpecialCharacters is false (tag)", () => {
+		const dedentFn = dedent.withOptions({ escapeSpecialCharacters: false });
+		expect(dedentFn`\xa0\t`).toBe("\\xa0\\t");
+		expect(dedentFn`\u5F1F`).toBe("\\u5F1F");
+		expect(dedentFn`\u{1F60A}`).toBe("\\u{1F60A}");
+	});
+
+	it("does not unescape when called as a function", () => {
+		expect(dedent("\\xa0\\t")).toBe("\\xa0\\t");
+		expect(dedent("\\u5F1F")).toBe("\\u5F1F");
+		expect(dedent("\\u{1F60A}")).toBe("\\u{1F60A}");
+	});
+
+	it("should escape when called with template strings", () => {
+		expect(dedent`a\xa0b`).toMatchSnapshot();
+		expect(dedent`\${hi}`).toMatchSnapshot();
+	});
+
+	it("should escape when called with template strings (multiline)", () => {
+		expect(dedent`
+			\${hi}
+			name
+		`).toMatchSnapshot();
+	});
+
 	describe.each([undefined, false, true])(
 		"with alignValues %s",
 		(alignValues) => {

--- a/src/dedent.test.ts
+++ b/src/dedent.test.ts
@@ -274,27 +274,48 @@ describe("dedent", () => {
 		expect(dedent(`\\nu`)).toBe("\\nu");
 	});
 
-	it("handles escape sequences like hex and unicode", () => {
-		expect(dedent`\xa0\t`).toBe("\xa0\t");
-		expect(dedent`\u5F1F`).toBe("\u5F1F");
-		expect(dedent`\u{1F60A}`).toBe("\u{1F60A}");
+	describe("escape sequences", () => {
+		it("passes through a hex escape", () => {
+			expect(dedent`\xa0\t`).toBe("\xa0\t");
+		});
+		it("passes through a fixed-length Unicode escape", () => {
+			expect(dedent`\u5F1F`).toBe("\u5F1F");
+		});
+		it("passes through a Unicode code point escape", () => {
+			expect(dedent`\u{1F60A}`).toBe("\u{1F60A}");
+		});
 	});
 
-	it("does not unescape when escapeSpecialCharacters is false (tag)", () => {
+	describe("escape sequences when escapeSpecialCharacters is false", () => {
 		const dedentFn = dedent.withOptions({ escapeSpecialCharacters: false });
-		expect(dedentFn`\xa0\t`).toBe("\\xa0\\t");
-		expect(dedentFn`\u5F1F`).toBe("\\u5F1F");
-		expect(dedentFn`\u{1F60A}`).toBe("\\u{1F60A}");
+		it("passes through a hex escape", () => {
+			expect(dedentFn`\xa0\t`).toBe("\\xa0\\t");
+		});
+		it("passes through a fixed-length Unicode escape", () => {
+			expect(dedentFn`\u5F1F`).toBe("\\u5F1F");
+		});
+		it("passes through a Unicode code point escape", () => {
+			expect(dedentFn`\u{1F60A}`).toBe("\\u{1F60A}");
+		});
 	});
 
-	it("does not unescape when called as a function", () => {
+	it("does not unescape when called as a function (hex escape)", () => {
 		expect(dedent("\\xa0\\t")).toBe("\\xa0\\t");
+	});
+
+	it("does not unescape when called as a function (fixed-length Unicode escape)", () => {
 		expect(dedent("\\u5F1F")).toBe("\\u5F1F");
+	});
+
+	it("does not unescape when called as a function (code point escape)", () => {
 		expect(dedent("\\u{1F60A}")).toBe("\\u{1F60A}");
 	});
 
-	it("should escape when called with template strings", () => {
+	it("should escape when called with template strings (hex escape)", () => {
 		expect(dedent`a\xa0b`).toMatchSnapshot();
+	});
+
+	it("should escape when called with template strings (escaped interpolation)", () => {
 		expect(dedent`\${hi}`).toMatchSnapshot();
 	});
 

--- a/src/dedent.test.ts
+++ b/src/dedent.test.ts
@@ -287,15 +287,18 @@ describe("dedent", () => {
 	});
 
 	describe("escape sequences when escapeSpecialCharacters is false", () => {
-		const dedentFn = dedent.withOptions({ escapeSpecialCharacters: false });
+		const dedenter = dedent.withOptions({ escapeSpecialCharacters: false });
+
 		it("passes through a hex escape", () => {
-			expect(dedentFn`\xa0\t`).toBe("\\xa0\\t");
+			expect(dedenter`\xa0\t`).toBe("\\xa0\\t");
 		});
+
 		it("passes through a fixed-length Unicode escape", () => {
-			expect(dedentFn`\u5F1F`).toBe("\\u5F1F");
+			expect(dedenter`\u5F1F`).toBe("\\u5F1F");
 		});
+
 		it("passes through a Unicode code point escape", () => {
-			expect(dedentFn`\u{1F60A}`).toBe("\\u{1F60A}");
+			expect(dedenter`\u{1F60A}`).toBe("\\u{1F60A}");
 		});
 	});
 

--- a/src/dedent.ts
+++ b/src/dedent.ts
@@ -79,9 +79,26 @@ function createDedent(options: DedentOptions) {
 			result = result.trim();
 		}
 
-		// handle escaped newlines at the end to ensure they don't get stripped too
+		// Unescape escapes after trimming so sequences like `\n`, `\t`,
+		// `\xHH` and `\u{...}` are preserved (fixes #24)
 		if (escapeSpecialCharacters) {
-			result = result.replace(/\\n/g, "\n");
+			result = result
+				.replace(/\\n/g, "\n")
+				.replace(/\\t/g, "\t")
+				.replace(/\\r/g, "\r")
+				.replace(/\\v/g, "\v")
+				.replace(/\\b/g, "\b")
+				.replace(/\\f/g, "\f")
+				.replace(/\\0/g, "\0")
+				.replace(/\\x([\da-fA-F]{2})/g, (_, h: string) =>
+					String.fromCharCode(parseInt(h, 16)),
+				)
+				.replace(/\\u\{([\da-fA-F]{1,6})\}/g, (_, h: string) =>
+					String.fromCodePoint(parseInt(h, 16)),
+				)
+				.replace(/\\u([\da-fA-F]{4})/g, (_, h: string) =>
+					String.fromCharCode(parseInt(h, 16)),
+				);
 		}
 
 		// Workaround for Bun issue with Unicode characters


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to dedent! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #24
- [x] That issue was marked as [`status: accepting prs`](https://github.com/dmnd/dedent/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/dmnd/dedent/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Fixes support for escape sequences in tagged templates by preserving raw template parts and unescaping explicit character escapes (e.g. `\n`, `\t`, `\xHH`, `\uXXXX`, `\u{...}`) only after indentation and trimming. 